### PR TITLE
Implement tag support

### DIFF
--- a/src/aws_hashicorp_packer_reaper/aws.py
+++ b/src/aws_hashicorp_packer_reaper/aws.py
@@ -1,6 +1,17 @@
 from pytz import UTC
 from datetime import datetime, timedelta
 
+class Tag(dict):
+    def __init__(self, **kwargs):
+        self.update(kwargs)
+
+    @property
+    def key(self):
+        return self["key"]
+
+    @property
+    def value(self):
+        return self["value"]
 
 class EC2Instance(dict):
     def __init__(self, i):

--- a/src/aws_hashicorp_packer_reaper/click_argument_types.py
+++ b/src/aws_hashicorp_packer_reaper/click_argument_types.py
@@ -1,4 +1,5 @@
 import click
+from aws_hashicorp_packer_reaper.aws import Tag
 import durations
 
 class Duration(click.ParamType):
@@ -18,3 +19,20 @@ class Duration(click.ParamType):
             return durations.Duration(value)
         except ValueError as e:
             self.fail(f'Could not parse "{value}" into duration ({e})', param, ctx)
+
+
+class TagParam(click.ParamType):
+    name = "keyvalue"
+
+    def convert(self, value, param, ctx):
+        splits = value.split("=")
+        if len(splits) == 1:
+            return Tag(
+                key=splits[0],
+                value=""
+            )
+        else:
+            return Tag(
+                key=splits[0],
+                value=splits[1]
+            )


### PR DESCRIPTION
Provide `--tag Key=Value` option to be able to run reaper against instances with specific tags.

Use case: different builds may tag instances differently, this allows for specific cleanups post-build